### PR TITLE
Enable reloadOnUpdate for tomee-maven-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ If you want to run your app locally in the production mode, run using
 mvn clean package tomee:run -Pproduction
 ```
 
+The application is deployed on the [Apache TomEE](http://tomee.apache.org/) server via the `tomee-maven-plugin`, which supports hot deployment of code changes (via the `reloadOnUpdate` setting).
+This means that you can make changes to the code in your IDE while the server is running, recompile, and have the server automatically pick up the changes and redeploy them.
+This setting is enabled by default in this project.
+
+One known limitation with hot deployment is that after deleting a `@Route`-annotated view, the route is are still navigable after automatic redeployment.
+In such case, the application must be restarted to remove the route from the registry permanently.   
+
 For documentation on using Vaadin Flow and CDI, visit [vaadin.com/docs](https://vaadin.com/docs/v14/flow/cdi/tutorial-cdi-basic.html)
 
 For more information on Vaadin Flow, visit https://vaadin.com/flow.

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,16 @@
                 <configuration>
                     <tomeeClassifier>webprofile</tomeeClassifier>
                     <context>ROOT</context>
+                    <synchronization>
+                        <extensions>
+                            <extension>.class</extension>
+                        </extensions>
+                    </synchronization>
+                    <reloadOnUpdate>true</reloadOnUpdate>
+                    <systemVariables>
+                        <openejb.system.apps>true</openejb.system.apps>
+                        <tomee.serialization.class.blacklist>-</tomee.serialization.class.blacklist>
+                    </systemVariables>
                 </configuration>
             </plugin>
 

--- a/src/main/java/com/vaadin/starter/skeleton/cdi/MainView.java
+++ b/src/main/java/com/vaadin/starter/skeleton/cdi/MainView.java
@@ -6,6 +6,7 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.PWA;
 
+import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 /**
@@ -18,7 +19,8 @@ public class MainView extends VerticalLayout {
     @Inject
     private MessageBean messageBean;
 
-    public MainView() {
+    @PostConstruct
+    public void init() {
         Button button = new Button("Click me",
                 event -> Notification.show(messageBean.getMessage()));
         add(button);


### PR DESCRIPTION
Fix #136. Fix #137.

Note that the session deserialization of TomEE does not like the bean reference in the constructor of `MainView`. Hence the move of view initialization to `@PostConstruct`-annotated method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-cdi/139)
<!-- Reviewable:end -->
