### PR TITLE
Makes the project compatible by default with those using Java 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ Import the project to the IDE of your choosing as a Maven project.
 
 Run application using
 ```
-mvn clean package tomee:run
+mvn wildfly:run
 ```
 
 Open [http://localhost:8080/](http://localhost:8080/) in browser.
 
 If you want to run your app locally in the production mode, run using
 ```
-mvn clean package tomee:run -Pproduction
+mvn clean package wildfly:run -Pproduction
 ```
 
 ### Running Integration Tests
@@ -31,7 +31,9 @@ and make sure you have a valid TestBench license installed.
 
 ### Deployment
 
-The application is deployed on the [Apache TomEE](http://tomee.apache.org/) server via the `tomee-maven-plugin`, which supports hot deployment of code changes (via the `reloadOnUpdate` setting).
+The project is a standard Java/Jakarta EE application, so you can deploy it as you see best, via IDE or using Maven plugins. Wildfly and TomEE plugins are pre-configured for easy testing. Wildfly plugin is used for integration tests. Currently only Wildfly properly supports Java 17.
+
+The application can be deployed on the [Apache TomEE](http://tomee.apache.org/) server via the `tomee-maven-plugin`, which supports hot deployment of code changes (via the `reloadOnUpdate` setting).
 This means that you can make changes to the code in your IDE while the server is running, recompile, and have the server automatically pick up the changes and redeploy them.
 This setting is enabled by default in this project.
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,12 +121,13 @@
     </dependencies>
 
     <build>
-        <defaultGoal>package tomee:run</defaultGoal>
+        <defaultGoal>package wildfly:run</defaultGoal>
+        
         <plugins>
             <plugin>
                 <groupId>org.apache.tomee.maven</groupId>
                 <artifactId>tomee-maven-plugin</artifactId>
-                <version>8.0.7</version>
+                <version>8.0.8</version>
                 <configuration>
                     <tomeeClassifier>webprofile</tomeeClassifier>
                     <context>ROOT</context>
@@ -142,6 +143,12 @@
                     </systemVariables>
                 </configuration>
             </plugin>
+            
+        <plugin>
+            <groupId>org.wildfly.plugins</groupId>
+            <artifactId>wildfly-maven-plugin</artifactId>
+            <version>2.1.0.Final</version>
+        </plugin>
                  
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -198,14 +205,15 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.tomee.maven</groupId>
-                        <artifactId>tomee-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>start</id>
                                 <phase>pre-integration-test</phase>
                                 <goals>
                                     <goal>start</goal>
+                                    <goal>deploy</goal>
                                 </goals>
                                 <configuration>
                                     <checkStarted>true</checkStarted>
@@ -215,7 +223,7 @@
                                 <id>stop</id>
                                 <phase>post-integration-test</phase>
                                 <goals>
-                                    <goal>stop</goal>
+                                    <goal>shutdown</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-web>
+    <context-root>/</context-root>
+</jboss-web>


### PR DESCRIPTION
## Description

Latest Wildfly has execellent support for Java 17. This change makes Widfly used by default so that the example has smooth experience for those who have Java 17 installed.

Fixes #311

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
