### PR TITLE
chore: update field-highlighter version to 23.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@vaadin/dialog": "23.1.4",
         "@vaadin/email-field": "23.1.4",
         "@vaadin/field-base": "23.1.4",
-        "@vaadin/field-highlighter": "23.1.2",
+        "@vaadin/field-highlighter": "23.1.3",
         "@vaadin/flow-frontend": "./target/flow-frontend",
         "@vaadin/form-layout": "23.1.4",
         "@vaadin/grid": "23.1.4",
@@ -3161,16 +3161,16 @@
       }
     },
     "node_modules/@vaadin/field-highlighter": {
-      "version": "23.1.2",
-      "resolved": "https://registry.npmjs.org/@vaadin/field-highlighter/-/field-highlighter-23.1.2.tgz",
-      "integrity": "sha512-JXZPzzB+gTUsxwUltuYl0Zj4b0IETK+OnV9fkEir+cPSX3yb6FcKmmzXVgaaZjzn72qAfaJJfZbAmxqQOoM8CA==",
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@vaadin/field-highlighter/-/field-highlighter-23.1.3.tgz",
+      "integrity": "sha512-msnU1XNk3g3l1h/ZzGWSKUkDWIyq7UIMLTtVAjKzguwm+XqeBMsSZ/nmAumqg/C/06duh9NmolBE7M+OX97Ocg==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "^23.1.2",
-        "@vaadin/vaadin-lumo-styles": "^23.1.2",
-        "@vaadin/vaadin-material-styles": "^23.1.2",
-        "@vaadin/vaadin-overlay": "^23.1.2",
-        "@vaadin/vaadin-themable-mixin": "^23.1.2",
+        "@vaadin/component-base": "^23.1.3",
+        "@vaadin/vaadin-lumo-styles": "^23.1.3",
+        "@vaadin/vaadin-material-styles": "^23.1.3",
+        "@vaadin/vaadin-overlay": "^23.1.3",
+        "@vaadin/vaadin-themable-mixin": "^23.1.3",
         "lit": "^2.0.0"
       }
     },
@@ -16504,9 +16504,9 @@
       }
     },
     "@vaadin/field-highlighter": {
-      "version": "23.1.2",
-      "resolved": "https://registry.npmjs.org/@vaadin/field-highlighter/-/field-highlighter-23.1.2.tgz",
-      "integrity": "sha512-JXZPzzB+gTUsxwUltuYl0Zj4b0IETK+OnV9fkEir+cPSX3yb6FcKmmzXVgaaZjzn72qAfaJJfZbAmxqQOoM8CA==",
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@vaadin/field-highlighter/-/field-highlighter-23.1.3.tgz",
+      "integrity": "sha512-msnU1XNk3g3l1h/ZzGWSKUkDWIyq7UIMLTtVAjKzguwm+XqeBMsSZ/nmAumqg/C/06duh9NmolBE7M+OX97Ocg==",
       "requires": {
         "@polymer/polymer": "3.5.1",
         "@vaadin/component-base": "23.1.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@vaadin/dialog": "23.1.4",
     "@vaadin/email-field": "23.1.4",
     "@vaadin/field-base": "23.1.4",
-    "@vaadin/field-highlighter": "23.1.2",
+    "@vaadin/field-highlighter": "23.1.3",
     "@vaadin/flow-frontend": "./target/flow-frontend",
     "@vaadin/form-layout": "23.1.4",
     "@vaadin/grid": "23.1.4",
@@ -283,7 +283,7 @@
       "workbox-precaching": "6.5.0",
       "workbox-webpack-plugin": "6.5.0"
     },
-    "hash": "6ef1418b9a6cc4d42fd828e294ca9abbb59fec89acbf7fb4cfd25a54c5949dab"
+    "hash": "44633d38650503f050eafc0d7d793a227af1defc1bc5fdfade86fc2d64c2996e"
   },
   "overrides": {
     "@vaadin/accordion": "$@vaadin/accordion",


### PR DESCRIPTION
Manual update due to SNYK-created PRs having so many conflicts in package-lock.json