### PR TITLE
test: fix validation build tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,9 @@
                                 </goals>
                                 <configuration>
                                     <checkStarted>true</checkStarted>
+                                    <server-args>
+                                        <server-arg>-b=0.0.0.0</server-arg>
+                                    </server-args>
                                 </configuration>
                             </execution>
                             <execution>

--- a/src/test/java/org/vaadin/example/AbstractViewTest.java
+++ b/src/test/java/org/vaadin/example/AbstractViewTest.java
@@ -64,6 +64,7 @@ public abstract class AbstractViewTest extends ParallelTest {
             setDriver(TestBench.createDriver(new ChromeDriver(chromeOptions)));
         }
         getDriver().get(getURL(route));
+        getCommandExecutor().waitForVaadin();
     }
 
     /**


### PR DESCRIPTION
Bind wildfly on all interfaces so that remote browser can reach application and wait for Vaadin to be ready before running test.

Fixes #413 
