### PR TITLE
chore: Pin WildFly version to 26.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,7 @@
                 <artifactId>wildfly-maven-plugin</artifactId>
                 <version>2.1.0.Final</version>
                 <configuration>
+                    <version>26.1.2.Final</version>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Related-to https://github.com/vaadin/skeleton-starter-flow-cdi/issues/489