### PR TITLE
fix: explicitly mark MainView as a CDI bean

### DIFF
--- a/src/main/java/org/vaadin/example/MainView.java
+++ b/src/main/java/org/vaadin/example/MainView.java
@@ -1,5 +1,6 @@
 package org.vaadin.example;
 
+import com.vaadin.cdi.annotation.CdiComponent;
 import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
@@ -16,6 +17,7 @@ import jakarta.inject.Inject;
  * that shows a greeting message in a notification.
  */
 @Route("")
+@CdiComponent
 public class MainView extends VerticalLayout {
 
     @Inject


### PR DESCRIPTION
## Description

Adding the `@CdiComponent` annotation to MainView allows it to be correctly detected as a CDI bean, so that lifecycle hooks are invoked. This is required because starting with Jakarta 10 bean-discovery-mode default value is 'annotated'. Another solution may have been to modify beans.xml to set bean-discovery-mode to 'all', but this is not the recommended way.

Relates to vaadin/flow#15625

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
