### PR TITLE
chore: upgrade wildfly dependency version to be compatible with vaadin 24.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,9 +100,9 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
-                <version>4.0.0.Final</version>
+                <version>5.1.2.Final</version>
                 <configuration>
-                    <version>27.0.1.Final</version>
+                    <version>35.0.1.Final</version>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
fixes #726 