### PR TITLE
chore: build and run production mode by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project can be used as a starting point to create your own Vaadin Flow 25.0 application with CDI 16.0.
 It contains all the necessary configuration and some placeholder files to get you started.
 
-Vaadin 25.0 is based on Jakarta EE 11.0 and requires Java 17.
+Vaadin 25.0 is based on Jakarta EE 11.0 and requires Java 21.
 
 The best way to use it is via [vaadin.com/start](https://vaadin.com/start) - you can get only the necessary parts and choose the package naming you want to use.
 
@@ -11,16 +11,16 @@ The best way to use it is via [vaadin.com/start](https://vaadin.com/start) - you
 
 Import the project to the IDE of your choosing as a Maven project. 
 
-Run application using
+Run application in development mode using
 ```
-mvn wildfly:run
+mvn wildfly:run -Pdevelopment
 ```
 
 Open [http://localhost:8080/](http://localhost:8080/) in browser.
 
 If you want to run your app locally in the production mode, run using
 ```
-mvn clean package wildfly:run -Pproduction
+mvn clean package wildfly:run
 ```
 
 ### Running Integration Tests

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
 
         <!-- Dependencies -->
-        <vaadin.version>25.0-SNAPSHOT</vaadin.version>
+        <vaadin.version>25.0.0-beta6</vaadin.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
 
         <!-- Dependencies -->
-        <vaadin.version>25.0.0-beta5</vaadin.version>
+        <vaadin.version>25.0-SNAPSHOT</vaadin.version>
     </properties>
 
     <repositories>
@@ -124,7 +124,6 @@
             <!--
                 Take care of synchronizing java dependencies and imports in
                 package.json and main.js files.
-                It also creates webpack.config.js if not exists yet.
             -->
             <plugin>
                 <groupId>com.vaadin</groupId>
@@ -143,21 +142,11 @@
 
     <profiles>
         <profile>
-            <!-- Production mode is activated using -Pproduction -->
+            <!-- Production mode is activated by default -->
             <id>production</id>
-            <dependencies>
-                <!-- Exclude development dependencies from production -->
-                <dependency>
-                    <groupId>com.vaadin</groupId>
-                    <artifactId>vaadin-core</artifactId>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>com.vaadin</groupId>
-                            <artifactId>vaadin-dev</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-            </dependencies>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <build>
                 <plugins>
                     <plugin>
@@ -173,6 +162,17 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <!-- Development mode is activated using -Pdevelopment -->
+            <id>development</id>
+            <dependencies>
+                <!-- Include development dependencies -->
+                <dependency>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>vaadin-dev</artifactId>
+                </dependency>
+            </dependencies>
         </profile>
 
         <profile>


### PR DESCRIPTION
Changes Maven configuration to activate production profile by default and adds development profile that adds `vaadin-dev`.

PartOf: vaadin/flow#22715
