### PR TITLE
Remove deprecated lumoImports from theme.json for Vaadin 25

### DIFF
--- a/src/main/frontend/themes/my-theme/theme.json
+++ b/src/main/frontend/themes/my-theme/theme.json
@@ -1,3 +1,2 @@
 {
-  "lumoImports" : [ "typography", "color", "spacing", "badge", "utility" ]
 }

--- a/src/main/java/org/vaadin/example/AppShell.java
+++ b/src/main/java/org/vaadin/example/AppShell.java
@@ -1,8 +1,10 @@
 package org.vaadin.example;
 
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.theme.Theme;
+import com.vaadin.flow.theme.lumo.Lumo;
 
 /**
  * Use the @PWA annotation make the application installable on phones, tablets
@@ -10,5 +12,6 @@ import com.vaadin.flow.theme.Theme;
  */
 @PWA(name = "Project Base for Vaadin", shortName = "Project Base")
 @Theme("my-theme")
+@StyleSheet(Lumo.UTILITY_STYLESHEET)
 public class AppShell implements AppShellConfigurator {
 }


### PR DESCRIPTION
## Summary

- Remove `lumoImports` from `theme.json` (no longer supported in Vaadin 25)
- Add `@StyleSheet(Lumo.UTILITY_STYLESHEET)` to AppShell for utility class loading
- In Vaadin 25, all Lumo modules except utility are loaded automatically
- The deprecated `lumoImports` property causes the production bundle validation to incorrectly skip the custom theme build, resulting in a blank page in production mode